### PR TITLE
feat - Group resources by 5 in the depends on to accelerate update

### DIFF
--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -9,7 +9,7 @@ from raven import Client
 from raven.transport import HTTPTransport
 
 MAX_RESOURCES_PER_TEMPLATE = 200
-RESSOURCE_BY_GROUP = 30  # SSM parameter rate limit is around 50
+RESSOURCE_BY_GROUP = 5
 
 
 def lambda_handler(*_):
@@ -42,7 +42,7 @@ def _lambda_handler():
     nested_template_urls = []
 
     number_of_chunk = len(cross_stack_references) / MAX_RESOURCES_PER_TEMPLATE
-    max_group_size = min(number_of_chunk/RESSOURCE_BY_GROUP, RESSOURCE_BY_GROUP)
+    max_group_size = int(max(min(RESSOURCE_BY_GROUP/number_of_chunk, RESSOURCE_BY_GROUP), 1))
 
     for items in _chunks(cross_stack_references, MAX_RESOURCES_PER_TEMPLATE):
         nested_template_urls.append(_generate_nested_template(items, max_group_size))

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -10,6 +10,7 @@ from raven.transport import HTTPTransport
 
 
 MAX_RESOURCES_PER_TEMPLATE = 200
+RESSOURCE_BY_GROUP = 5
 
 
 def lambda_handler(*_):
@@ -110,6 +111,7 @@ def _build_unsigned_url(template_name):
 def _generate_nested_template(cross_stack_references):
     last_ref_id = None
     ssm_resources = {}
+    resource_count = 0
 
     for ref in cross_stack_references:
         ref_id = _generate_hash(ref['CrossStackRefId'])
@@ -128,7 +130,10 @@ def _generate_nested_template(cross_stack_references):
 
         ssm_resources[ref_id] = ssm_resource
 
-        last_ref_id = ref_id
+        if resource_count % RESSOURCE_BY_GROUP == 0:
+            last_ref_id = ref_id
+
+        resource_count += 1
 
     imports_replication_template = {
         'AWSTemplateFormatVersion': '2010-09-09',


### PR DESCRIPTION
To accelerate the process of creating and updating the stacks of parameters, the dependson parameter will change every 5 resources to group them. The value of 5 is what our tests showed to be the optimal value not to be throttled by SMS.