### PR TITLE
fix(docs) Add SENTRY_ENV to deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Start by deploying the **Exporter**
 
 ```
 export AWS_DEFAULT_REGION=<EXPORTER_REGION>
-make deploy-exporter SENTRY_DSN=https://...@sentry.io/... 
+make deploy-exporter SENTRY_ENV=prod SENTRY_DSN=https://...@sentry.io/... 
 ```
 
 #### Importer


### PR DESCRIPTION
This variable is required when deploying the exporter