### PR TITLE
Feat - Switch from SSM to outputs + SAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,23 +16,25 @@ __check_defined = \
 	$(if $(value $1),, \
 		$(error Undefined $1$(if $2, ($2))))
 
+install:
+	@pip install aws-sam-cli
+
 check-bucket:
 	@aws s3api head-bucket --bucket $(BUCKET_NAME) &> /dev/null || aws s3 mb s3://$(BUCKET_NAME)
 
 package-importer: check-bucket
 	@./package_lambda.sh importer/lambda cross_region_importer
-	@aws cloudformation package --template-file $(IMPORTER_SOURCE_TEMPLATE_PATH) --s3-bucket $(BUCKET_NAME) --s3-prefix cloudformation/$(IMPORTER_SOURCE_TEMPLATE_PATH).yml --output-template-file $(IMPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH)
+	@sam package --template-file $(IMPORTER_SOURCE_TEMPLATE_PATH) --s3-bucket $(BUCKET_NAME) --s3-prefix cloudformation/$(IMPORTER_SOURCE_TEMPLATE_PATH).yml --output-template-file $(IMPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH)
 
 deploy-importer: package-importer
 	$(call check_defined, CROSS_STACK_REF_TABLE_ARN, Ex: make deploy-importer CROSS_STACK_REF_TABLE_ARN=arn:aws:dynamodb:region:accountid:table/tablename)
-	aws cloudformation deploy --template-file $(IMPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH) --stack-name $(IMPORTER_STACK_NAME) --capabilities CAPABILITY_IAM --parameter-overrides CrossStackRefTableArn=$(CROSS_STACK_REF_TABLE_ARN)
-
+	@sam deploy --template-file $(IMPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH) --stack-name $(IMPORTER_STACK_NAME) --capabilities CAPABILITY_IAM --parameter-overrides CrossStackRefTableArn=$(CROSS_STACK_REF_TABLE_ARN)
 
 package-exporter: check-bucket
 	@./package_lambda.sh exporter/lambda cross_region_import_replication
-	@aws cloudformation package --template-file $(EXPORTER_SOURCE_TEMPLATE_PATH) --s3-bucket $(BUCKET_NAME) --s3-prefix cloudformation/$(EXPORTER_SOURCE_TEMPLATE_PATH).yml --output-template-file $(EXPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH)
+	@sam package --template-file $(EXPORTER_SOURCE_TEMPLATE_PATH) --s3-bucket $(BUCKET_NAME) --s3-prefix cloudformation/$(EXPORTER_SOURCE_TEMPLATE_PATH).yml --output-template-file $(EXPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH)
 
 deploy-exporter: package-exporter
 	$(call check_defined, SENTRY_DSN, Ex: make deploy-exporter SENTRY_DSN=https://...@sentry.io/...)
 	$(call check_defined, SENTRY_ENV, Ex: make deploy-exporter SENTRY_ENV=dev)
-	aws cloudformation deploy --template-file $(EXPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH) --stack-name $(EXPORTER_STACK_NAME) --capabilities CAPABILITY_IAM --parameter-overrides SentryDsn=$(SENTRY_DSN) SentryEnvironment=$(SENTRY_ENV)
+	@sam deploy --template-file $(EXPORTER_GENERATED_TEMPLATE_ABSOLUTE_PATH) --stack-name $(EXPORTER_STACK_NAME) --capabilities CAPABILITY_IAM --parameter-overrides SentryDsn=$(SENTRY_DSN) SentryEnvironment=$(SENTRY_ENV)

--- a/exporter/cloudformation/cross-region-exporter.yml
+++ b/exporter/cloudformation/cross-region-exporter.yml
@@ -1,5 +1,5 @@
 ---
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Defines the cross-region exporter resources
 Parameters:
   SentryDsn:
@@ -15,11 +15,11 @@ Resources:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-      - AttributeName: CrossStackRefId
-        AttributeType: S
+        - AttributeName: CrossStackRefId
+          AttributeType: S
       KeySchema:
-      - AttributeName: CrossStackRefId
-        KeyType: HASH
+        - AttributeName: CrossStackRefId
+          KeyType: HASH
       BillingMode: PAY_PER_REQUEST
       StreamSpecification:
         StreamViewType: KEYS_ONLY
@@ -38,15 +38,15 @@ Resources:
       Environment:
         Variables:
           SENTRY_DSN: !Ref SentryDsn
-          GENERATED_STACK_NAME: !Sub '${AWS::StackName}-ImportsReplication'
+          GENERATED_STACK_NAME: !Sub "${AWS::StackName}-ImportsReplication"
           CROSS_STACK_REF_TABLE_NAME: !Ref CrossStackRefTable
           SENTRY_ENVIRONMENT: !Ref SentryEnvironment
           TEMPLATE_BUCKET: !Ref CrossStackRefBucket
       Tags:
-      - Key: SecurityClassification
-        Value: Green
-      - Key: Component
-        Value: CrossRegionImportReplicationLambdaFunction
+        - Key: SecurityClassification
+          Value: Green
+        - Key: Component
+          Value: CrossRegionImportReplicationLambdaFunction
 
   CrossRegionImportReplicationLambdaFunctionLambdaRole:
     Type: AWS::IAM::Role
@@ -62,54 +62,54 @@ Resources:
               - sts:AssumeRole
       Path: /
       Policies:
-      - PolicyName: ReadAndUpdateDynamoDb
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - dynamodb:Scan
-            Resource: !GetAtt CrossStackRefTable.Arn
-      - PolicyName: CreateAndUpdateGeneratedCloudformation
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - cloudformation:CreateStack
-            - cloudformation:UpdateStack
-            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-ImportsReplication/*'
-      - PolicyName: PutAndDeleteSsmParameter
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - ssm:PutParameter
-            - ssm:DeleteParameter
-            - ssm:AddTagsToResource
-            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
-      - PolicyName: UploadTemplateToS3
-        PolicyDocument:
-          Statement:
-          - Effect: "Allow"
-            Action:
-            - s3:PutObject
-            - s3:GetObject
-            Resource: !Sub '${CrossStackRefBucket.Arn}/*'
-      - PolicyName: AccessDynamoStream
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: Allow
-            Action:
-            - dynamodb:GetRecords
-            - dynamodb:GetShardIterator
-            - dynamodb:DescribeStream
-            - dynamodb:ListStreams
-            Resource: !GetAtt CrossStackRefTable.StreamArn
+        - PolicyName: ReadAndUpdateDynamoDb
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                Resource: !GetAtt CrossStackRefTable.Arn
+        - PolicyName: CreateAndUpdateGeneratedCloudformation
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-ImportsReplication/*"
+        - PolicyName: PutAndDeleteSsmParameter
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:AddTagsToResource
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*"
+        - PolicyName: UploadTemplateToS3
+          PolicyDocument:
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: !Sub "${CrossStackRefBucket.Arn}/*"
+        - PolicyName: AccessDynamoStream
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetRecords
+                  - dynamodb:GetShardIterator
+                  - dynamodb:DescribeStream
+                  - dynamodb:ListStreams
+                Resource: !GetAtt CrossStackRefTable.StreamArn
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
   CrossRegionImporterLambdaEventSourceMapping:
     Type: AWS::Lambda::EventSourceMapping
@@ -117,7 +117,7 @@ Resources:
       EventSourceArn: !GetAtt CrossStackRefTable.StreamArn
       FunctionName: !Ref CrossRegionImportReplicationLambdaFunction
       StartingPosition: TRIM_HORIZON
-      
+
 Outputs:
   CrossStackRefTableArn:
     Value: !GetAtt CrossStackRefTable.Arn

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -10,7 +10,7 @@ from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
 sentry_sdk.init(integrations=[AwsLambdaIntegration(timeout_warning=True)])
 
-MAX_RESOURCES_PER_TEMPLATE = 200
+MAX_OUTPUTS_PER_TEMPLATE = 200
 
 
 def lambda_handler(*_):
@@ -33,7 +33,7 @@ def _lambda_handler():
 
     if cross_stack_references:
         nested_template_urls = []
-        for items in _chunks(cross_stack_references, MAX_RESOURCES_PER_TEMPLATE):
+        for items in _chunks(cross_stack_references, MAX_OUTPUTS_PER_TEMPLATE):
             nested_template_urls.append(_generate_nested_template(items))
 
         master_template_resources = {}

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -5,92 +5,73 @@ from uuid import uuid4
 
 import boto3
 import botocore
-from raven import Client
-from raven.transport import HTTPTransport
+import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+sentry_sdk.init(integrations=[AwsLambdaIntegration()])
 
 MAX_RESOURCES_PER_TEMPLATE = 200
-RESSOURCE_BY_GROUP = 5
 
 
 def lambda_handler(*_):
     try:
         _lambda_handler()
     except:
-        # Using a the default transport does not work in a Lambda function.
-        # Must use the HTTPTransport.
-        Client(
-            dsn=os.environ['SENTRY_DSN'],
-            environment=os.environ['SENTRY_ENVIRONMENT'],
-            transport=HTTPTransport
-        ).captureException()
-        # Must raise, otherwise the Lambda will be marked as successful, and the exception
-        # will not be logged to CloudWatch logs.
         raise
 
 
 def _lambda_handler():
-    dynamodb_resource = boto3.resource('dynamodb')
-    cross_stack_ref_table = dynamodb_resource.Table(os.environ['CROSS_STACK_REF_TABLE_NAME'])
+    dynamodb_resource = boto3.resource("dynamodb")
+    cross_stack_ref_table = dynamodb_resource.Table(os.environ["CROSS_STACK_REF_TABLE_NAME"])
 
     scan_response = cross_stack_ref_table.scan()
-    cross_stack_references = scan_response['Items']
+    cross_stack_references = scan_response["Items"]
 
-    while scan_response.get('LastEvaluatedKey'):
-        scan_response = cross_stack_ref_table.scan(ExclusiveStartKey=scan_response['LastEvaluatedKey'])
-        cross_stack_references.extend(scan_response['Items'])
+    while scan_response.get("LastEvaluatedKey"):
+        scan_response = cross_stack_ref_table.scan(ExclusiveStartKey=scan_response["LastEvaluatedKey"])
+        cross_stack_references.extend(scan_response["Items"])
 
     if cross_stack_references:
-        number_of_chunk = len(cross_stack_references) / MAX_RESOURCES_PER_TEMPLATE
-        max_group_size = int(max(min(RESSOURCE_BY_GROUP/number_of_chunk, RESSOURCE_BY_GROUP), 1))
-
         nested_template_urls = []
         for items in _chunks(cross_stack_references, MAX_RESOURCES_PER_TEMPLATE):
-            nested_template_urls.append(_generate_nested_template(items, max_group_size))
+            nested_template_urls.append(_generate_nested_template(items))
 
         master_template_resources = {}
         for i, url in enumerate(nested_template_urls):
-            master_template_resources[f"ParameterChunk{i}"] = {
-                "Type": "AWS::CloudFormation::Stack",
-                "Properties": {
-                    "TemplateURL": url
-                }
-            }
+            master_template_resources[f"Chunk{i}"] = {"Type": "AWS::CloudFormation::Stack", "Properties": {"TemplateURL": url}}
     else:
         master_template_resources = {
-            'PlaceHolderParameter': {
-                'Type': 'AWS::SSM::Parameter',
-                'Properties': {
-                    'Value': {'Ref': "AWS::StackName"},
-                    'Type': 'String'
-                },
+            "PlaceHolderParameter": {
+                "Type": "AWS::CloudFormation::WaitConditionHandle",
+                "Properties": {},
             }
         }
 
     master_template = {
-        'AWSTemplateFormatVersion': '2010-09-09',
-        'Description': 'Auto-generated templates to simulate the standard importation behaviour on other regions',
-        'Resources': master_template_resources
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Description": "Auto-generated templates to simulate the standard importation behaviour on other regions",
+        "Resources": master_template_resources,
     }
 
-    cloudformation_client = boto3.client('cloudformation')
+    cloudformation_client = boto3.client("cloudformation")
 
-    _upload_template(os.environ['GENERATED_STACK_NAME'], json.dumps(master_template))
-    template_url = _build_unsigned_url(os.environ['GENERATED_STACK_NAME'])
+    _upload_template(os.environ["GENERATED_STACK_NAME"], json.dumps(master_template))
+    template_url = _build_unsigned_url(os.environ["GENERATED_STACK_NAME"])
 
     try:
         cloudformation_client.update_stack(
-            StackName=os.environ['GENERATED_STACK_NAME'],
+            StackName=os.environ["GENERATED_STACK_NAME"],
             TemplateURL=template_url,
         )
     except botocore.exceptions.ClientError as e:
-        message = e.response['Error']['Message']
-        if 'does not exist' in message:
+        message = e.response["Error"]["Message"]
+        if "does not exist" in message:
             cloudformation_client.create_stack(
-                StackName=os.environ['GENERATED_STACK_NAME'],
+                StackName=os.environ["GENERATED_STACK_NAME"],
                 TemplateURL=template_url,
             )
-        elif 'No updates are to be performed.' in message:
-            print('No updates are to be performed.')
+        elif "No updates are to be performed." in message:
+            print("No updates are to be performed.")
         else:
             raise
 
@@ -100,63 +81,49 @@ def _generate_hash(string_to_hash):
 
 
 def _upload_template(template_name, template_content):
-    s3_resource = boto3.resource('s3')
-    template_object = s3_resource.Object(os.environ['TEMPLATE_BUCKET'], template_name)
+    s3_resource = boto3.resource("s3")
+    template_object = s3_resource.Object(os.environ["TEMPLATE_BUCKET"], template_name)
     template_object.put(Body=template_content.encode())
 
 
 def _build_unsigned_url(template_name):
-    s3_resource = boto3.resource('s3')
-    template_object = s3_resource.Object(
-        os.environ['TEMPLATE_BUCKET'],
-        template_name
-    )
+    s3_resource = boto3.resource("s3")
+    template_object = s3_resource.Object(os.environ["TEMPLATE_BUCKET"], template_name)
 
-    return '{host}/{bucket}/{key}'.format(
+    return "{host}/{bucket}/{key}".format(
         host=template_object.meta.client.meta.endpoint_url,
         bucket=template_object.bucket_name,
         key=template_object.key,
     )
 
 
-def _generate_nested_template(cross_stack_references, max_group_size):
-    last_ref_id = None
-    ssm_resources = {}
-    resource_count = 0
+def _generate_nested_template(cross_stack_references):
+    template = {
+        "AWSTemplateFormatVersion": "2010-09-09",
+        "Resources": {
+            "PlaceHolderParameter": {"Type": "AWS::CloudFormation::WaitConditionHandle", "Properties": {}},
+        },
+        "Outputs": {},
+    }
+    output_count = 0
 
     for ref in cross_stack_references:
-        ref_id = _generate_hash(ref['CrossStackRefId'])
-        ssm_resource = {
-            'Type': 'AWS::SSM::Parameter',
-            'Properties': {
-                'Name': {'Fn::Sub': "${AWS::StackName}." + ref_id},
-                'Description': f'Imported by {ref["ImporterStackId"]}.{ref["ImporterLogicalResourceId"]}.{ref["ImporterLabel"]}',
-                'Value': {'Fn::ImportValue': ref['ExportName']},
-                'Type': 'String'
-            },
+        ref_id = _generate_hash(ref["CrossStackRefId"])
+        output = {
+            "Value": {"Fn::ImportValue": ref["ExportName"]},
+            "Description": f'Imported by {ref["ImporterStackId"]}.{ref["ImporterLogicalResourceId"]}.{ref["ImporterLabel"]}',
         }
 
-        if last_ref_id:
-            ssm_resource['DependsOn'] = last_ref_id  # Required to prevent SSM throttling exceptions
+        template["Outputs"][ref_id] = output
 
-        ssm_resources[ref_id] = ssm_resource
-
-        if resource_count % max_group_size == 0:
-            last_ref_id = ref_id
-
-        resource_count += 1
-
-    imports_replication_template = {
-        'AWSTemplateFormatVersion': '2010-09-09',
-        'Resources': ssm_resources
-    }
+        output_count += 1
 
     template_name = f'{os.environ["GENERATED_STACK_NAME"]}.{uuid4()}'
 
-    _upload_template(template_name, json.dumps(imports_replication_template))
+    _upload_template(template_name, json.dumps(template))
     return _build_unsigned_url(template_name)
 
 
 def _chunks(l, n):
     for i in range(0, len(l), n):
-        yield l[i:i + n]
+        yield l[i : i + n]

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -8,7 +8,7 @@ import botocore
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 
-sentry_sdk.init(integrations=[AwsLambdaIntegration()])
+sentry_sdk.init(integrations=[AwsLambdaIntegration(timeout_warning=True)])
 
 MAX_RESOURCES_PER_TEMPLATE = 200
 
@@ -105,7 +105,6 @@ def _generate_nested_template(cross_stack_references):
         },
         "Outputs": {},
     }
-    output_count = 0
 
     for ref in cross_stack_references:
         ref_id = _generate_hash(ref["CrossStackRefId"])
@@ -115,8 +114,6 @@ def _generate_nested_template(cross_stack_references):
         }
 
         template["Outputs"][ref_id] = output
-
-        output_count += 1
 
     template_name = f'{os.environ["GENERATED_STACK_NAME"]}.{uuid4()}'
 

--- a/exporter/lambda/requirements.txt
+++ b/exporter/lambda/requirements.txt
@@ -1,1 +1,1 @@
-raven==6.10.0
+sentry-sdk<1.0.0


### PR DESCRIPTION
Switch from SSM parameters to outputs, which is much faster.
Also switched to SAM and sentry-sdk to be more up-to-date.
Added a dummy resource because it is required in the template.