### PR TITLE
Chore - Bump python to 3.9

### DIFF
--- a/exporter/cloudformation/cross-region-exporter.yml
+++ b/exporter/cloudformation/cross-region-exporter.yml
@@ -43,7 +43,7 @@ Resources:
       Code: ../../dist/cross_region_import_replication.zip
       Handler: cross_region_import_replication.lambda_handler
       Role: !GetAtt CrossRegionImportReplicationLambdaFunctionLambdaRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
       Environment:
         Variables:

--- a/importer/cloudformation/cross-region-importer.yml
+++ b/importer/cloudformation/cross-region-importer.yml
@@ -57,7 +57,7 @@ Resources:
       Handler: cross_region_importer.lambda_handler
       Role: !GetAtt CrossRegionImporterResourceRole.Arn
       Code: ../../dist/cross_region_importer.zip
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
Python 3.6 will be deprecated in Lambdas on August 17. Currently deployed in dev and stage. 