### PR TITLE
Chore: Pin urllib3 in importer lambda requirements

### DIFF
--- a/importer/lambda/requirements.txt
+++ b/importer/lambda/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 tenacity==5.0.3
+urllib3==1.26.16


### PR DESCRIPTION
Dependabot's pr (https://github.com/PokaInc/cfn-cross-region-export/pull/23) bump requests version which added support to urllib3>=2.0. This version on urllib3 is not supported by lambda and should be pinned to latest supported version.