### PR TITLE
Fix: Bump sentry-sdk

### DIFF
--- a/exporter/lambda/requirements.txt
+++ b/exporter/lambda/requirements.txt
@@ -1,1 +1,1 @@
-sentry-sdk<1.0.0
+sentry-sdk==1.25.1


### PR DESCRIPTION
Bump `sentry-sdk` for security alert.