### PR TITLE
Infra - 1713 :: Re-evaluate lambda memory according to trusted advisor - cfn-cross-region-export

### DIFF
--- a/exporter/cloudformation/cross-region-exporter.yml
+++ b/exporter/cloudformation/cross-region-exporter.yml
@@ -37,6 +37,7 @@ Resources:
       Handler: cross_region_import_replication.lambda_handler
       Role: !GetAtt CrossRegionImportReplicationLambdaFunctionLambdaRole.Arn
       Runtime: python3.9
+      MemorySize: 160
       Timeout: 300
       Environment:
         Variables:


### PR DESCRIPTION
Bump memory size of specific lambda functions by trusted advisor recommendation.