### PR TITLE
INFRA-2550 add update stack retry logic

### DIFF
--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -7,7 +7,7 @@ import boto3
 import botocore
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
-from tenacity import retry, retry_if_exception_type, stop_after_attempt
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 sentry_sdk.init(integrations=[AwsLambdaIntegration(timeout_warning=True)])
 
@@ -76,7 +76,7 @@ def _lambda_handler():
 
 
 @retry(
-    wait=45,
+    wait=wait_fixed(45),
     retry=retry_if_exception_type(botocore.exceptions.ClientError),
     stop=stop_after_attempt(3),
     reraise=True,

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -71,6 +71,8 @@ def _lambda_handler():
             )
         elif "No updates are to be performed." in message:
             print("No updates are to be performed.")
+        elif "UPDATE_IN_PROGRESS" in message:
+            print("Stack update in progress")
         else:
             raise
 

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -78,7 +78,7 @@ def _lambda_handler():
 @retry(
     wait=wait_fixed(45),
     retry=retry_if_exception_type(botocore.exceptions.ClientError),
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(1),
     reraise=True,
 )
 def _update_stack(template_url):

--- a/exporter/lambda/cross_region_import_replication.py
+++ b/exporter/lambda/cross_region_import_replication.py
@@ -7,10 +7,13 @@ import boto3
 import botocore
 import sentry_sdk
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+from tenacity import retry, retry_if_exception_type, stop_after_attempt
 
 sentry_sdk.init(integrations=[AwsLambdaIntegration(timeout_warning=True)])
 
 MAX_OUTPUTS_PER_TEMPLATE = 200
+
+cloudformation_client = boto3.client("cloudformation")
 
 
 def lambda_handler(*_):
@@ -53,16 +56,12 @@ def _lambda_handler():
         "Resources": master_template_resources,
     }
 
-    cloudformation_client = boto3.client("cloudformation")
 
     _upload_template(os.environ["GENERATED_STACK_NAME"], json.dumps(master_template))
     template_url = _build_unsigned_url(os.environ["GENERATED_STACK_NAME"])
 
     try:
-        cloudformation_client.update_stack(
-            StackName=os.environ["GENERATED_STACK_NAME"],
-            TemplateURL=template_url,
-        )
+        _update_stack(template_url)
     except botocore.exceptions.ClientError as e:
         message = e.response["Error"]["Message"]
         if "does not exist" in message:
@@ -74,6 +73,19 @@ def _lambda_handler():
             print("No updates are to be performed.")
         else:
             raise
+
+
+@retry(
+    wait=45,
+    retry=retry_if_exception_type(botocore.exceptions.ClientError),
+    stop=stop_after_attempt(3),
+    reraise=True,
+)
+def _update_stack(template_url):
+    cloudformation_client.update_stack(
+            StackName=os.environ["GENERATED_STACK_NAME"],
+            TemplateURL=template_url,
+        )
 
 
 def _generate_hash(string_to_hash):

--- a/exporter/lambda/requirements.txt
+++ b/exporter/lambda/requirements.txt
@@ -1,2 +1,3 @@
 sentry-sdk==1.25.1
+tenacity==5.0.3
 urllib3==1.26.16


### PR DESCRIPTION
Correctly handle stacks that are UPDATE_IN_PROGRESS in cross-region-exports.
Adding a retry block to the update stack function in order to be able to retry a couple times before declaring true failure.

https://pokainc.atlassian.net/jira/software/projects/INFRA/boards/162?selectedIssue=INFRA-2550