### PR TITLE
INFRA-4485 :: Fix - Add missing permission

### DIFF
--- a/exporter/cloudformation/cross-region-exporter.yml
+++ b/exporter/cloudformation/cross-region-exporter.yml
@@ -82,6 +82,7 @@ Resources:
                 Action:
                   - cloudformation:CreateStack
                   - cloudformation:UpdateStack
+                  - cloudformation:DeleteStack
                 Resource: 
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-ImportsReplication/*"
                   - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-ImportsReplication-Chunk*-*/*"


### PR DESCRIPTION
If the number of exports is reduced enough, the lambda tries to delete the now unnecessary chunk stacks. However, the Lambda currently doesn’t have this permissions, so it simply fails, leaving us with a bunch on dead references that prevent other stack deletion. 

https://pokainc.atlassian.net/browse/INFRA-4485